### PR TITLE
Fix dangling pointer access in main output

### DIFF
--- a/src/main-output.cpp
+++ b/src/main-output.cpp
@@ -26,31 +26,25 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 static obs_output_t *main_out = nullptr;
 static bool main_output_running = false;
 
-void main_output_init(const char *default_name)
-{
-	if (main_out)
-		return;
-
-	obs_data_t *settings = obs_data_create();
-	obs_data_set_string(settings, "ndi_name", default_name);
-	main_out = obs_output_create("ndi_output", "NDI Main Output", settings,
-				     nullptr);
-	obs_data_release(settings);
-}
-
 void main_output_start(const char *output_name)
 {
-	if (main_output_running || !main_out)
+	if (main_output_running)
 		return;
 
 	blog(LOG_INFO,
 	     "main_output_start: starting NDI main output with name '%s'",
 	     output_name);
 
-	obs_data_t *settings = obs_output_get_settings(main_out);
+	obs_data_t *settings = obs_data_create();
 	obs_data_set_string(settings, "ndi_name", output_name);
-	obs_output_update(main_out, settings);
+	main_out = obs_output_create("ndi_output", "NDI Main Output", settings,
+				     nullptr);
 	obs_data_release(settings);
+	if (!main_out) {
+		blog(LOG_ERROR,
+		     "main_output_start: failed to create NDI main output");
+		return;
+	}
 
 	obs_output_start(main_out);
 	main_output_running = true;
@@ -66,19 +60,12 @@ void main_output_stop()
 	blog(LOG_INFO, "main_output_stop: stopping NDI main output");
 
 	obs_output_stop(main_out);
+	obs_output_release(main_out);
+	main_out = nullptr;
 
 	main_output_running = false;
 
 	blog(LOG_INFO, "main_output_stop: stopped NDI main output");
-}
-
-void main_output_deinit()
-{
-	blog(LOG_INFO, "+main_output_deinit()");
-	obs_output_release(main_out);
-	main_out = nullptr;
-	main_output_running = false;
-	blog(LOG_INFO, "-main_output_deinit()");
 }
 
 bool main_output_is_running()

--- a/src/main-output.h
+++ b/src/main-output.h
@@ -18,8 +18,6 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #pragma once
 
-void main_output_init(const char *default_name);
 void main_output_start(const char *output_name);
 void main_output_stop();
-void main_output_deinit();
 bool main_output_is_running();

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -140,7 +140,6 @@ bool obs_module_load(void)
 		Config *conf = Config::Current();
 		conf->Load();
 
-		main_output_init(conf->OutputName.toUtf8().constData());
 		preview_output_init(
 			conf->PreviewOutputName.toUtf8().constData());
 
@@ -187,7 +186,6 @@ bool obs_module_load(void)
 					main_output_stop();
 
 					preview_output_deinit();
-					main_output_deinit();
 				}
 			},
 			static_cast<void *>(conf));


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR defers the allocation of the NDI main output context.

Fix #908

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
After OBS Studio has reset its video output, the NDI main output still held a pointer to the old video output and tried to access it when starting the NDI main output.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 37

I followed the steps described in the issue #908 and confirmed it crashed without this PR but does not crash with this PR.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
