### PR TITLE
Fix the macOS plugin output path to install directly into the OBS Plugins directory.

### DIFF
--- a/cmake/macos/defaults.cmake
+++ b/cmake/macos/defaults.cmake
@@ -33,7 +33,7 @@ set_property(CACHE CMAKE_OSX_DEPLOYMENT_TARGET PROPERTY STRINGS 13.0 12.0 11.0)
 # Use Applications directory as default install destination
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX
-      "$ENV{HOME}/Library/Application Support/obs-studio/plugins;~/Library/Application Support/obs-studio/plugins"
+      "~/Library/Application Support/obs-studio/plugins"
       CACHE STRING "Directory to install OBS after building" FORCE)
 endif()
 

--- a/cmake/macos/defaults.cmake
+++ b/cmake/macos/defaults.cmake
@@ -33,7 +33,7 @@ set_property(CACHE CMAKE_OSX_DEPLOYMENT_TARGET PROPERTY STRINGS 13.0 12.0 11.0)
 # Use Applications directory as default install destination
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX
-      "~/Library/Application Support/obs-studio/plugins"
+      "$ENV{HOME}/Library/Application Support/obs-studio/plugins;~/Library/Application Support/obs-studio/plugins"
       CACHE STRING "Directory to install OBS after building" FORCE)
 endif()
 

--- a/cmake/macos/defaults.cmake
+++ b/cmake/macos/defaults.cmake
@@ -33,7 +33,7 @@ set_property(CACHE CMAKE_OSX_DEPLOYMENT_TARGET PROPERTY STRINGS 13.0 12.0 11.0)
 # Use Applications directory as default install destination
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX
-      "$ENV{HOME}/Library/Application Support/obs-studio/plugins"
+      "~/Library/Application Support/obs-studio/plugins"
       CACHE STRING "Directory to install OBS after building" FORCE)
 endif()
 


### PR DESCRIPTION
Hey 👋, I believe it is currently safe to hardcode the path according to the [OBS Plugins guide](https://obsproject.com/kb/plugins-guide#install-or-remove-plugins). This approach will help us address the [#904](https://github.com/obs-ndi/obs-ndi/issues/904) issue, eliminating the need to manually execute commands to fix this seemingly simple "bug" where paths are not recognized correctly through the CMake Environment variables.