### PR TITLE
Fixed bug in ndi_output_destroy() and upgraded to OBS 30.0.2

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -13,12 +13,12 @@
             "5. Update libobs.patch following the instructions in ./cmake/common/buildspec_common.cmake ~ line 76-91"
         ],
         "obs-studio": {
-            "version": "30.0.0",
+            "version": "30.0.2",
             "baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
             "label": "OBS sources",
             "hashes": {
-                "macos": "c23dd463862b1a8f40365d84fd52105d7eafc3614fb3d470b695ba28a6e4da06",
-                "windows-x64": "2bfdadf5f46ba56276d588b77653a10b9e2b2e3c05d8029b27a25b8ada9ab474"
+                "macos": "be12c3ad0a85713750d8325e4b1db75086223402d7080d0e3c2833d7c5e83c27",
+                "windows-x64": "970058c49322cfa9cd6d620abb393fed89743ba7e74bd9dbb6ebe0ea8141d9c7"
             }
         },
         "prebuilt": {

--- a/src/obs-ndi-output.cpp
+++ b/src/obs-ndi-output.cpp
@@ -290,8 +290,8 @@ void ndi_output_destroy(void *data)
 		bfree(o->audio_conv_buffer);
 		o->audio_conv_buffer = nullptr;
 	}
-	bfree(o);
 	blog(LOG_INFO, "[obs-ndi] -ndi_output_destroy('%s'...)", o->ndi_name);
+	bfree(o);
 }
 
 void ndi_output_rawvideo(void *data, video_data *frame)


### PR DESCRIPTION
* Fixed bug in ndi_output_destroy(), which was causing a segfault after plugin configuration changes were made due to "o" being freed before being used in a blog() call.
* Updated to use OBS 30.0.2