### PR TITLE
Message when QLibrary fails at loading libndi

### DIFF
--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -275,6 +275,9 @@ const NDIlib_v4 *load_ndilib()
 					     "[obs-ndi] load_ndilib: ERROR: NDIlib_v5_load not found in loaded library");
 				}
 			} else {
+				blog(LOG_ERROR,
+					"[obs-ndi] load_ndilib: ERROR: QLibrary returned the following error: '%s'",
+					loaded_lib->errorString().toUtf8().constData()) ;
 				delete loaded_lib;
 				loaded_lib = nullptr;
 			}


### PR DESCRIPTION
    When obs-ndi fails at loading libdni, the messages displayed
    in obs can be very misleading. In my case, it was :

    [...]
    info: [obs-ndi] load_ndilib: Trying '/usr/lib/libndi.so.5'
    info: [obs-ndi] load_ndilib: Trying '/usr/local/lib/libndi.so.5'
    info: [obs-ndi] load_ndilib: Found NDI library at '/usr/local/lib/libndi.so.5'
    error: [obs-ndi] load_ndilib: ERROR: Can't find the NDI library
    [...]

    Which was not very helpful, and I could see in the history of the
    project that several users stumbled onto this.

    So I added a single line to display the last error message from QLibrary :

    [...]
    info: [obs-ndi] load_ndilib: Trying '/usr/lib/libndi.so.5'
    info: [obs-ndi] load_ndilib: Trying '/usr/local/lib/libndi.so.5'
    info: [obs-ndi] load_ndilib: Found NDI library at '/usr/local/lib/libndi.so.5'
    error: [obs-ndi] load_ndilib: ERROR: QLibrary returned the following error: 'Cannot
    load library /usr/local/lib/libndi.so.5: (libavahi-common.so.3:
    Ne peut ouvrir le fichier d'objet partagé: Aucun fichier ou dossier de ce nom)'
    error: [obs-ndi] load_ndilib: ERROR: Can't find the NDI library
    [...]

    ( sorry, my locale is in French :)
    Now I know that it was libavahi the problem in my case.

    PS: this commit message is soooooo longer than the code added !