### PR TITLE
close audio thread

### DIFF
--- a/src/preview-output.cpp
+++ b/src/preview-output.cpp
@@ -156,6 +156,7 @@ void preview_output_stop()
 	obs_leave_graphics();
 
 	video_output_close(context.video_queue);
+	audio_output_close(context.dummy_audio_queue);
 
 	context.enabled = false;
 


### PR DESCRIPTION
https://github.com/obs-ndi/obs-ndi/issues/963

audio_output_open is called for dummy_audio_queue while no audio_output_close.
This makes audio_thread of NDI is still running after obs_shutdown.

It seems you forget call audio_output_close.

