### PR TITLE
Update libndi-get.sh for Linux NDI library Install

### DIFF
--- a/CI/libndi-get.sh
+++ b/CI/libndi-get.sh
@@ -75,17 +75,29 @@ if [ "$1" == "install" ]; then
     echo
 fi
 
-echo "Clean-up : Removing temporary folder"
-rm -rf $LIBNDI_TMP
-# Confirm temporary directory was removed.
 
-# Check if the directory exists and is a directory.
-if [[ ! -d "$LIBNDI_TMP" ]]; then
-    echo "Temporary directory $LIBNDI_TMP does not exist anymore (good!)"
+
+# Allow to keep the temporary files (to use with libndi-package.sh)
+if [ "$1" == "nocleanup" ]; then
+        echo "No Clean-up requested."
+
 else
-    echo "Failed to clean-up temporary directory."
-    echo "Please clean this up manully - All should be in $LIBNDI_TMP"
-    exit 1
+
+        # Otherwise continue with Clean-up
+
+        echo "Clean-up : Removing temporary folder"
+        rm -rf $LIBNDI_TMP
+        # Confirm temporary directory was removed.
+
+        # Check if the directory exists and is a directory.
+        if [[ ! -d "$LIBNDI_TMP" ]]; then
+            echo "Temporary directory $LIBNDI_TMP does not exist anymore (good!)"
+        else
+            echo "Failed to clean-up temporary directory."
+            echo "Please clean this up manully - All should be in $LIBNDI_TMP"
+            exit 1
+        fi
+
 fi
 
 # Enjoy!


### PR DESCRIPTION
Updated the linux libndi install script helper

The original script worked on Debian (12.5) but not on Ubuntu 22.04 LTS.

This proposed version of the install script for the Libraries has been tested successfully on :
- Ubuntu 22.04.1 LTS 
- Debian 12 Bookworm

![image](https://github.com/obs-ndi/obs-ndi/assets/2151317/b84547ed-e8a3-4604-997f-6d2189cd89e3)


The script also work for NDI v6 (just need to change LIBNDI_INSTALLER_NAME for v6).

This should address the following issues : 
- https://github.com/obs-ndi/obs-ndi/issues/977
- https://github.com/obs-ndi/obs-ndi/issues/949
