### PR TITLE
Update SDK with NDI v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Network Audio/Video in OBS-Studio using NDI technology
 
 ## Requirements
 * OBS >= 30.0.0 (Qt6 & x64)
-* NDI 5 Runtime  
+* NDI 6 Runtime  
   We are not allowed to directly distribute the NDI runtime here,
   but you can get it from either
   [the links below](#required-install-ndi-runtime), or installing

--- a/lib/ndi/Processing.NDI.DynamicLoad.h
+++ b/lib/ndi/Processing.NDI.DynamicLoad.h
@@ -8,7 +8,7 @@
 //
 //***********************************************************************************************************
 //
-// Copyright (C) 2023 Vizrt NDI AB. All rights reserved.
+// Copyright (C) 2023-2024 Vizrt NDI AB. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files(the "Software"), to deal in the Software without restriction, including

--- a/lib/ndi/Processing.NDI.Find.h
+++ b/lib/ndi/Processing.NDI.Find.h
@@ -8,7 +8,7 @@
 //
 //***********************************************************************************************************
 //
-// Copyright (C) 2023 Vizrt NDI AB. All rights reserved.
+// Copyright (C) 2023-2024 Vizrt NDI AB. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files(the "Software"), to deal in the Software without restriction, including

--- a/lib/ndi/Processing.NDI.FrameSync.h
+++ b/lib/ndi/Processing.NDI.FrameSync.h
@@ -8,7 +8,7 @@
 //
 //***********************************************************************************************************
 //
-// Copyright (C) 2023 Vizrt NDI AB. All rights reserved.
+// Copyright (C) 2023-2024 Vizrt NDI AB. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files(the "Software"), to deal in the Software without restriction, including

--- a/lib/ndi/Processing.NDI.Lib.cplusplus.h
+++ b/lib/ndi/Processing.NDI.Lib.cplusplus.h
@@ -8,7 +8,7 @@
 //
 //***********************************************************************************************************
 //
-// Copyright (C) 2023 Vizrt NDI AB. All rights reserved.
+// Copyright (C) 2023-2024 Vizrt NDI AB. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files(the "Software"), to deal in the Software without restriction, including

--- a/lib/ndi/Processing.NDI.Lib.h
+++ b/lib/ndi/Processing.NDI.Lib.h
@@ -8,7 +8,7 @@
 //
 //***********************************************************************************************************
 //
-// Copyright (C) 2023 Vizrt NDI AB. All rights reserved.
+// Copyright (C) 2023-2024 Vizrt NDI AB. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files(the "Software"), to deal in the Software without restriction, including
@@ -49,22 +49,22 @@
 #			endif // __cplusplus
 #			ifdef _WIN64
 #				define NDILIB_LIBRARY_NAME  "Processing.NDI.Lib.x64.dll"
-#				define NDILIB_REDIST_FOLDER "NDI_RUNTIME_DIR_V5"
-#				define NDILIB_REDIST_URL    "http://ndi.link/NDIRedistV5"
+#				define NDILIB_REDIST_FOLDER "NDI_RUNTIME_DIR_V6"
+#				define NDILIB_REDIST_URL    "http://ndi.link/NDIRedistV6"
 #			else // _WIN64
 #				define NDILIB_LIBRARY_NAME  "Processing.NDI.Lib.x86.dll"
-#				define NDILIB_REDIST_FOLDER "NDI_RUNTIME_DIR_V5"
-#				define NDILIB_REDIST_URL    "http://ndi.link/NDIRedistV5"
+#				define NDILIB_REDIST_FOLDER "NDI_RUNTIME_DIR_V6"
+#				define NDILIB_REDIST_URL    "http://ndi.link/NDIRedistV6"
 #			endif // _WIN64
 #		endif // PROCESSINGNDILIB_EXPORTS
 #	else // _WIN32
 #		ifdef __APPLE__
 #			define NDILIB_LIBRARY_NAME  "libndi.dylib"
-#			define NDILIB_REDIST_FOLDER "NDI_RUNTIME_DIR_V5"
-#			define NDILIB_REDIST_URL    "http://ndi.link/NDIRedistV5Apple"
+#			define NDILIB_REDIST_FOLDER "NDI_RUNTIME_DIR_V6"
+#			define NDILIB_REDIST_URL    "http://ndi.link/NDIRedistV6Apple"
 #		else // __APPLE__
-#			define NDILIB_LIBRARY_NAME  "libndi.so.5"
-#			define NDILIB_REDIST_FOLDER "NDI_RUNTIME_DIR_V5"
+#			define NDILIB_LIBRARY_NAME  "libndi.so.6"
+#			define NDILIB_REDIST_FOLDER "NDI_RUNTIME_DIR_V6"
 #			define NDILIB_REDIST_URL    ""
 #		endif // __APPLE__
 #		ifdef __cplusplus

--- a/lib/ndi/Processing.NDI.Recv.ex.h
+++ b/lib/ndi/Processing.NDI.Recv.ex.h
@@ -8,7 +8,7 @@
 //
 //***********************************************************************************************************
 //
-// Copyright (C) 2023 Vizrt NDI AB. All rights reserved.
+// Copyright (C) 2023-2024 Vizrt NDI AB. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files(the "Software"), to deal in the Software without restriction, including

--- a/lib/ndi/Processing.NDI.Recv.h
+++ b/lib/ndi/Processing.NDI.Recv.h
@@ -8,7 +8,7 @@
 //
 //***********************************************************************************************************
 //
-// Copyright (C) 2023 Vizrt NDI AB. All rights reserved.
+// Copyright (C) 2023-2024 Vizrt NDI AB. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files(the "Software"), to deal in the Software without restriction, including

--- a/lib/ndi/Processing.NDI.Routing.h
+++ b/lib/ndi/Processing.NDI.Routing.h
@@ -8,7 +8,7 @@
 //
 //***********************************************************************************************************
 //
-// Copyright (C) 2023 Vizrt NDI AB. All rights reserved.
+// Copyright (C) 2023-2024 Vizrt NDI AB. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files(the "Software"), to deal in the Software without restriction, including

--- a/lib/ndi/Processing.NDI.Send.h
+++ b/lib/ndi/Processing.NDI.Send.h
@@ -8,7 +8,7 @@
 //
 //***********************************************************************************************************
 //
-// Copyright (C) 2023 Vizrt NDI AB. All rights reserved.
+// Copyright (C) 2023-2024 Vizrt NDI AB. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files(the "Software"), to deal in the Software without restriction, including

--- a/lib/ndi/Processing.NDI.compat.h
+++ b/lib/ndi/Processing.NDI.compat.h
@@ -8,7 +8,7 @@
 //
 //***********************************************************************************************************
 //
-// Copyright (C) 2023 Vizrt NDI AB. All rights reserved.
+// Copyright (C) 2023-2024 Vizrt NDI AB. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files(the "Software"), to deal in the Software without restriction, including

--- a/lib/ndi/Processing.NDI.structs.h
+++ b/lib/ndi/Processing.NDI.structs.h
@@ -8,7 +8,7 @@
 //
 //***********************************************************************************************************
 //
-// Copyright (C) 2023 Vizrt NDI AB. All rights reserved.
+// Copyright (C) 2023-2024 Vizrt NDI AB. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files(the "Software"), to deal in the Software without restriction, including

--- a/lib/ndi/Processing.NDI.utilities.h
+++ b/lib/ndi/Processing.NDI.utilities.h
@@ -8,7 +8,7 @@
 //
 //***********************************************************************************************************
 //
-// Copyright (C) 2023 Vizrt NDI AB. All rights reserved.
+// Copyright (C) 2023-2024 Vizrt NDI AB. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files(the "Software"), to deal in the Software without restriction, including


### PR DESCRIPTION
Update NDI SDK to V6.0.0

Fucntional test on OBS 30.1.2:
- Windows 10 (up-to-date)
- WIndows 11 (up-to-date) (as compiled on this machine)

- Ubuntu 22.04.1 (as compiled on that same machine)

- MacOS 14 (Apple Chip)

Result example on Ubuntu:
![image](https://github.com/obs-ndi/obs-ndi/assets/2151317/06349f42-4a66-483c-ba9b-3be75c669875)

Result on Mac : 
![image](https://github.com/obs-ndi/obs-ndi/assets/2151317/d82e12a8-8e6a-4513-a0f4-27b4b726fa0a)


This will effectively use the NDI SDK v6 libraries / Runtime.