### PR TITLE
Update libndi-get.sh to use libNDI v6

### DIFF
--- a/CI/libndi-get.sh
+++ b/CI/libndi-get.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-LIBNDI_INSTALLER_NAME="Install_NDI_SDK_v5_Linux"
+LIBNDI_INSTALLER_NAME="Install_NDI_SDK_v6_Linux"
 LIBNDI_INSTALLER="$LIBNDI_INSTALLER_NAME.tar.gz"
 
 # Use temporary directory


### PR DESCRIPTION
Use LibNDI v6 for linux install to match windows & mac as well.