### PR TITLE
Audio-Only Mode Fix

### DIFF
--- a/src/obs-ndi-source.cpp
+++ b/src/obs-ndi-source.cpp
@@ -496,7 +496,7 @@ void *ndi_source_thread(void *data)
 				break;
 			case PROP_BW_AUDIO_ONLY:
 				recv_desc.bandwidth =
-					NDIlib_recv_bandwidth_audio_only;		
+					NDIlib_recv_bandwidth_audio_only;
 				break;
 			}
 			blog(LOG_INFO,

--- a/src/obs-ndi-source.cpp
+++ b/src/obs-ndi-source.cpp
@@ -496,10 +496,7 @@ void *ndi_source_thread(void *data)
 				break;
 			case PROP_BW_AUDIO_ONLY:
 				recv_desc.bandwidth =
-					NDIlib_recv_bandwidth_audio_only;
-				obs_source_output_video(
-					obs_source,
-					config_most_recent.blank_frame);
+					NDIlib_recv_bandwidth_audio_only;		
 				break;
 			}
 			blog(LOG_INFO,


### PR DESCRIPTION
Fix audio bug that audio-Only mode does not work when restarting OBS.

Main bug with workaround solution: https://github.com/obs-ndi/obs-ndi/issues/592

Should fix the issues :
https://github.com/obs-ndi/obs-ndi/issues/429
https://github.com/obs-ndi/obs-ndi/issues/578
https://github.com/obs-ndi/obs-ndi/issues/981
https://github.com/obs-ndi/obs-ndi/issues/906
https://github.com/obs-ndi/obs-ndi/issues/621
https://github.com/obs-ndi/obs-ndi/issues/467
https://github.com/obs-ndi/obs-ndi/issues/298

This was tested and confirmed fixing the bug on Win 11 Home + Win 10 Home on OBS 30.1.1 (for the issue)

DO NOT MERGE!

This re-introduce another issue that the "last frame" of the input is not "cleared" when the bandwidth settings change from another one to "audio_only".